### PR TITLE
Configure database URL for Postgres

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL=postgresql://neondb_owner:npg_YQkwJc2ir7hg@ep-ancient-math-a8zw10p1-pooler.eastus2.azure.neon.tech/neondb?sslmode=require&channel_binding=require

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
## Summary
- add `.env` with a Postgres connection string
- ignore `node_modules` with a `.gitignore`
- update `DATABASE_URL` to point at a Neon-hosted Postgres instance

## Testing
- `npx drizzle-kit push` *(fails: 403 Forbidden while fetching drizzle-kit from npm registry)*

------
https://chatgpt.com/codex/tasks/task_b_68a4727daac4832aa4c62c125f029128